### PR TITLE
Add OpenAI and OpenRouter support

### DIFF
--- a/aiSystemManager.gs
+++ b/aiSystemManager.gs
@@ -1,0 +1,219 @@
+// Utilities for managing AI provider configuration and calls
+
+const PROP_PROVIDER = 'AI_PROVIDER';
+const PROP_MODEL = 'AI_MODEL';
+const PROP_OPENAI_KEY = 'OPENAI_API_KEY';
+const PROP_OPENROUTER_KEY = 'OPENROUTER_API_KEY';
+
+function setProvider(provider) {
+  PropertiesService.getUserProperties().setProperty(PROP_PROVIDER, provider);
+}
+
+function getProvider() {
+  return PropertiesService.getUserProperties().getProperty(PROP_PROVIDER) || 'openai';
+}
+
+function setModel(model) {
+  PropertiesService.getUserProperties().setProperty(PROP_MODEL, model);
+}
+
+function getModel() {
+  return PropertiesService.getUserProperties().getProperty(PROP_MODEL) || '';
+}
+
+function getOpenRouterModel() {
+  return getModel();
+}
+
+function setApiKey(apiKey) {
+  var props = PropertiesService.getUserProperties();
+  var provider = getProvider();
+  if (provider === 'openrouter') {
+    props.setProperty(PROP_OPENROUTER_KEY, apiKey);
+  } else {
+    props.setProperty(PROP_OPENAI_KEY, apiKey);
+  }
+}
+
+function getOpenAIApiKey() {
+  return PropertiesService.getUserProperties().getProperty(PROP_OPENAI_KEY);
+}
+
+function getOpenRouterApiKey() {
+  return PropertiesService.getUserProperties().getProperty(PROP_OPENROUTER_KEY);
+}
+
+function getApiKey() {
+  var provider = getProvider();
+  return provider === 'openrouter' ? getOpenRouterApiKey() : getOpenAIApiKey();
+}
+
+function getApiSettings() {
+  return {
+    provider: getProvider(),
+    apiKey: getApiKey(),
+    model: getModel()
+  };
+}
+
+function AI_OpenRouter() {
+  Logger.log('Calling OpenRouter with args:', arguments);
+  var prompt = Array.prototype.slice.call(arguments).join(' ');
+  var apiKey = getApiKey();
+  var model = getOpenRouterModel();
+  if (!apiKey) {
+    Browser.msgBox('No OpenRouter API Key Set. To use this function, please set the API key first by using the Set API Key menu item.');
+    return;
+  }
+  if (!model) {
+    Browser.msgBox('No AI Model Set. Please select a model using the Set AI Model menu.');
+    return;
+  }
+  var url = 'https://openrouter.ai/api/v1/chat/completions';
+  var input = {
+    model: model,
+    messages: [{ role: 'user', content: prompt }]
+  };
+  var options = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + apiKey,
+      'HTTP-Referer': 'https://www.aahsheet.com',
+      'X-Title': 'AAH Sheet'
+    },
+    method: 'post',
+    payload: JSON.stringify(input)
+  };
+  var attempts = 0;
+  var emailSent = false;
+  while (attempts < 3) {
+    try {
+      var response = UrlFetchApp.fetch(url, options);
+      var json = response.getContentText();
+      var data = JSON.parse(json);
+      return data.choices[0].message.content;
+    } catch (error) {
+      attempts++;
+      Logger.log('OpenRouter API call failed. Attempt: ' + attempts + '. Error: ' + error);
+      if (!emailSent && error.toString().toLowerCase().includes('billing')) {
+        if (typeof handleBillingError === 'function') handleBillingError(error);
+        emailSent = true;
+      }
+    }
+  }
+  if (attempts >= 3) {
+    Browser.msgBox('OpenRouter API failed. They are busy. Try again shortly.');
+    throw new Error('OpenRouter API call failed after ' + attempts + ' attempts. Check the log for error details.');
+  }
+}
+
+function AI_OpenAI() {
+  Logger.log('Calling OpenAI with args:', arguments);
+  var prompt = Array.prototype.slice.call(arguments).join(' ');
+  var apiKey = getApiKey();
+  var model = getModel();
+  if (!apiKey) {
+    Browser.msgBox('No OpenAI API Key Set. To use this function, please set the API key first by using the Set API Key menu item.');
+    return;
+  }
+  if (!model) {
+    Browser.msgBox('No AI Model Set. Please select a model using the Set AI Model menu.');
+    return;
+  }
+  var url = 'https://api.openai.com/v1/chat/completions';
+  var input = {
+    model: model,
+    messages: [{ role: 'user', content: prompt }]
+  };
+  var options = {
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + apiKey
+    },
+    method: 'post',
+    payload: JSON.stringify(input)
+  };
+  var attempts = 0;
+  var emailSent = false;
+  while (attempts < 3) {
+    try {
+      var response = UrlFetchApp.fetch(url, options);
+      var json = response.getContentText();
+      var data = JSON.parse(json);
+      return data.choices[0].message.content;
+    } catch (error) {
+      attempts++;
+      Logger.log('OpenAI API call failed. Attempt: ' + attempts + '. Error: ' + error);
+      if (!emailSent && error.toString().toLowerCase().includes('billing')) {
+        if (typeof handleBillingError === 'function') handleBillingError(error);
+        emailSent = true;
+      }
+    }
+  }
+  if (attempts >= 3) {
+    Browser.msgBox('OpenAI API failed. They are busy. Try again shortly.');
+    throw new Error('OpenAI API call failed after ' + attempts + ' attempts. Check the log for error details.');
+  }
+}
+
+function fetchOpenRouterModelsFromAPI() {
+  var apiKey = getOpenRouterApiKey();
+  if (!apiKey) {
+    throw new Error('OpenRouter API Key is not set.');
+  }
+  var url = 'https://openrouter.ai/api/v1/models';
+  var options = { method: 'GET', headers: { Authorization: 'Bearer ' + apiKey } };
+  try {
+    var response = UrlFetchApp.fetch(url, options);
+    var data = JSON.parse(response.getContentText());
+    if (!data || !data.data || !Array.isArray(data.data)) {
+      throw new Error('Unexpected response format from OpenRouter API.');
+    }
+    data.data.sort(function(a, b) {
+      var nameA = a.name || '';
+      var nameB = b.name || '';
+      return nameA.localeCompare(nameB);
+    });
+    return data.data.map(function(model) {
+      return { name: model.name || 'N/A', id: model.id || 'N/A' };
+    });
+  } catch (e) {
+    throw new Error('Failed to fetch OpenRouter models: ' + e.message);
+  }
+}
+
+function fetchOpenAIModels() {
+  var apiKey = getOpenAIApiKey();
+  if (!apiKey) {
+    throw new Error('OpenAI API Key is not set.');
+  }
+  var url = 'https://api.openai.com/v1/models';
+  var options = {
+    method: 'get',
+    headers: { Authorization: 'Bearer ' + apiKey },
+    muteHttpExceptions: true
+  };
+  try {
+    var response = UrlFetchApp.fetch(url, options);
+    var responseCode = response.getResponseCode();
+    var responseText = response.getContentText();
+    if (responseCode !== 200) {
+      throw new Error('Failed to fetch. Code: ' + responseCode + ' | ' + responseText);
+    }
+    var data = JSON.parse(responseText);
+    if (!data || !Array.isArray(data.data)) {
+      throw new Error('Invalid data format returned from OpenAI API.');
+    }
+    return data.data.map(function(item) { return { id: item.id }; });
+  } catch (e) {
+    throw new Error('Error fetching OpenAI models: ' + e.message);
+  }
+}
+
+function fetchModels(provider) {
+  if (provider === 'openrouter') {
+    return fetchOpenRouterModelsFromAPI();
+  }
+  return fetchOpenAIModels();
+}
+

--- a/chatSessionCoordinator.gs
+++ b/chatSessionCoordinator.gs
@@ -11,7 +11,11 @@ function processUserInput(prompt) {
       }));
     }
     appendChatMessage('user', prompt);
-    var response = callAiProvider(prompt, dataJson);
+    var provider = getProvider();
+    var fullPrompt = prompt + '\n\nData:\n' + dataJson;
+    var response = provider === 'openrouter'
+      ? AI_OpenRouter(fullPrompt)
+      : AI_OpenAI(fullPrompt);
     appendChatMessage('assistant', response);
     return { success: true, messages: getChatHistory() };
   } catch (e) {

--- a/setupChatSidebar.html
+++ b/setupChatSidebar.html
@@ -33,6 +33,13 @@
     <input id="promptInput" type="text" placeholder="Type a message..." maxlength="500" />
     <button id="sendBtn">Send</button>
     <select id="modelSelector"></select>
+    <button id="fetchModelsBtn">Fetch Models</button>
+    <select id="providerSelector">
+      <option value="openai">OpenAI</option>
+      <option value="openrouter">OpenRouter</option>
+    </select>
+    <input id="apiKeyInput" type="password" placeholder="API Key" />
+    <button id="saveKeyBtn">Save Key</button>
     <button id="clearBtn">Clear</button>
     <button id="exportBtn">Export</button>
   </div>
@@ -55,16 +62,16 @@
       n.style.display = 'none';
     }
 
-    function populateModel(config) {
+    function populateModels(list, selected) {
       const sel = document.getElementById('modelSelector');
       sel.innerHTML = '';
-      config.models.forEach(m => {
+      list.forEach(m => {
         const o = document.createElement('option');
-        o.value = m; o.textContent = m;
+        o.value = m.id || m.name || m;
+        o.textContent = m.name || m.id || m;
         sel.appendChild(o);
       });
-      if (config.defaultModel) sel.value = config.defaultModel;
-      if (config.theme === 'dark') document.body.classList.add('dark-theme');
+      if (selected) sel.value = selected;
     }
 
     function render(log) {
@@ -91,7 +98,6 @@
       const sendBtn = document.getElementById('sendBtn');
       inp.disabled = true;
       sendBtn.disabled = true;
-      const model = document.getElementById('modelSelector').value;
       google.script.run
         .withSuccessHandler(res => {
           chatLog = res;
@@ -105,7 +111,7 @@
           inp.disabled = false;
           sendBtn.disabled = false;
         })
-        .processUserInput(text, model);
+        .processUserInput(text);
       inp.value = '';
     }
 
@@ -144,21 +150,61 @@
         .exportChatLog();
     }
 
+    function fetchModels() {
+      clearNotification();
+      const provider = document.getElementById('providerSelector').value;
+      const btn = document.getElementById('fetchModelsBtn');
+      btn.disabled = true;
+      google.script.run
+        .withSuccessHandler(models => {
+          populateModels(models, document.getElementById('modelSelector').value);
+          btn.disabled = false;
+        })
+        .withFailureHandler(err => {
+          console.error(err);
+          showNotification(err.message || 'Failed to fetch models.', 'error');
+          btn.disabled = false;
+        })
+        .fetchModels(provider);
+    }
+
     document.getElementById('sendBtn').addEventListener('click', sendMessage);
     document.getElementById('promptInput').addEventListener('keydown', e => {
       if (e.key === 'Enter') sendMessage();
     });
     document.getElementById('clearBtn').addEventListener('click', clearChat);
     document.getElementById('exportBtn').addEventListener('click', exportChat);
+    document.getElementById('saveKeyBtn').addEventListener('click', () => {
+      const key = document.getElementById('apiKeyInput').value.trim();
+      google.script.run.setApiKey(key);
+    });
+    document.getElementById('providerSelector').addEventListener('change', () => {
+      const p = document.getElementById('providerSelector').value;
+      google.script.run.setProvider(p);
+    });
+    document.getElementById('modelSelector').addEventListener('change', () => {
+      const m = document.getElementById('modelSelector').value;
+      google.script.run.setModel(m);
+    });
+    document.getElementById('fetchModelsBtn').addEventListener('click', fetchModels);
 
-    window.addEventListener('load', () => {
+    function loadSettings() {
       google.script.run
-        .withSuccessHandler(populateModel)
+        .withSuccessHandler(cfg => {
+          document.getElementById('providerSelector').value = cfg.provider || 'openai';
+          document.getElementById('apiKeyInput').value = cfg.apiKey || '';
+          fetchModels();
+          if (cfg.model) document.getElementById('modelSelector').value = cfg.model;
+        })
         .withFailureHandler(err => {
           console.error(err);
           showNotification(err.message || 'Failed to load configuration.', 'error');
         })
-        .getApiConfig();
+        .getApiSettings();
+    }
+
+    window.addEventListener('load', () => {
+      loadSettings();
       google.script.run
         .withSuccessHandler(res => {
           chatLog = res;


### PR DESCRIPTION
## Summary
- add aiSystemManager.gs containing helper functions for OpenAI/OpenRouter API keys and model fetching
- modify chatSessionCoordinator to route prompts to selected provider
- update sidebar HTML to allow selecting provider, saving API keys, and fetching models

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854ca8189948327b0cfe881599e0e4b