### PR TITLE
Add column/row reference parsing for chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,21 @@
 Data Sidebar Chat
 
 This project provides a sidebar chat interface for Google Sheets. After installing the script, a custom menu **Data Whisperer** will appear. Use the *Show Sidebar* item to open the chat sidebar.
+
+## Column and row analysis
+
+When your prompt references specific columns or rows (e.g. `col A`, `column C`, `row 5`, or `rows 2-4`), the add‑on will automatically gather that data from the active sheet. The extracted data is passed to the AI as JSON with the following shape:
+
+```json
+{
+  "columns": {
+    "A": ["value1", "value2"],
+    "C": ["..."]
+  },
+  "rows": {
+    "3": ["r3c1", "r3c2", "..."]
+  }
+}
+```
+
+Column data starts from row 2 so the header row remains untouched. Invalid or out‑of‑bounds references are ignored.

--- a/chatSessionCoordinator.gs
+++ b/chatSessionCoordinator.gs
@@ -1,27 +1,91 @@
 function processUserInput(prompt) {
   try {
-    var range = getSelectedRangeAsJson();
-    var dataJson = JSON.stringify([]);
-    if (!range.error) {
-      var headers = range.headers;
-      dataJson = JSON.stringify(range.values.map(function(row) {
-        var obj = {};
-        headers.forEach(function(h, i) { obj[h] = row[i]; });
-        return obj;
-      }));
-    }
+    var dataObj = extractSheetDataFromPrompt(prompt);
+    var dataJson = JSON.stringify(dataObj);
     appendChatMessage('user', prompt);
     var provider = getProvider();
     var fullPrompt = prompt + '\n\nData:\n' + dataJson;
-    var response = provider === 'openrouter'
-      ? AI_OpenRouter(fullPrompt)
-      : AI_OpenAI(fullPrompt);
+    var response =
+      provider === 'openrouter' ? AI_OpenRouter(fullPrompt) : AI_OpenAI(fullPrompt);
     appendChatMessage('assistant', response);
     return { success: true, messages: getChatHistory() };
   } catch (e) {
     Logger.log(e);
     return { success: false, error: e.toString() };
   }
+}
+
+function extractSheetDataFromPrompt(prompt) {
+  var sheet = SpreadsheetApp.getActiveSheet();
+  if (!sheet) return { columns: {}, rows: {} };
+  var maxRow = sheet.getLastRow();
+  var maxCol = sheet.getLastColumn();
+
+  var columns = {};
+  var colLetters = [];
+  var colRegex = /\bcol(?:umn)?s?\s+([a-z]+(?:\s*(?:,|and)\s*[a-z]+)*)/gi;
+  var match;
+  while ((match = colRegex.exec(prompt)) !== null) {
+    var parts = match[1]
+      .split(/(?:,|and)/i)
+      .map(function(p) { return p.trim().toUpperCase(); })
+      .filter(function(p) { return p; });
+    Array.prototype.push.apply(colLetters, parts);
+  }
+  colLetters = Array.from(new Set(colLetters));
+  colLetters.forEach(function(letter) {
+    var colIndex = columnLetterToIndex(letter);
+    if (colIndex >= 1 && colIndex <= maxCol) {
+      var colValues = [];
+      if (maxRow > 1) {
+        colValues = sheet.getRange(2, colIndex, maxRow - 1, 1).getValues();
+        colValues = colValues.map(function(r) { return r[0]; });
+      }
+      columns[letter] = colValues;
+    }
+  });
+
+  var rows = {};
+  var rowNumbers = [];
+  var rowRegex = /\brow[s]?\s+(\d+(?:\s*-\s*\d+)?(?:\s*(?:,|and)\s*\d+(?:\s*-\s*\d+)?)*)/gi;
+  while ((match = rowRegex.exec(prompt)) !== null) {
+    var segments = match[1].split(/(?:,|and)/i);
+    segments.forEach(function(seg) {
+      var rangeParts = seg.trim().split(/\s*-\s*/);
+      if (rangeParts.length === 2) {
+        var start = parseInt(rangeParts[0], 10);
+        var end = parseInt(rangeParts[1], 10);
+        if (!isNaN(start) && !isNaN(end)) {
+          if (start > end) {
+            var tmp = start;
+            start = end;
+            end = tmp;
+          }
+          for (var i = start; i <= end; i++) rowNumbers.push(i);
+        }
+      } else {
+        var num = parseInt(rangeParts[0], 10);
+        if (!isNaN(num)) rowNumbers.push(num);
+      }
+    });
+  }
+  rowNumbers = Array.from(new Set(rowNumbers));
+  rowNumbers.forEach(function(n) {
+    if (n >= 1 && n <= maxRow) {
+      var rowData = sheet.getRange(n, 1, 1, maxCol).getValues()[0];
+      rows[n] = rowData;
+    }
+  });
+
+  return { columns: columns, rows: rows };
+}
+
+function columnLetterToIndex(letter) {
+  var col = 0;
+  for (var i = 0; i < letter.length; i++) {
+    col = col * 26 + (letter.charCodeAt(i) - 64);
+  }
+  return col;
 }
 
 


### PR DESCRIPTION
## Summary
- parse prompts for `col` and `row` references
- extract sheet data for mentioned columns and rows
- send extracted data to the AI provider as JSON
- document the new capability in the README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6854d3ac825483279b3302e7ee560d85