### PR TITLE
Fix missing sidebar functions

### DIFF
--- a/chatSessionCoordinator.gs
+++ b/chatSessionCoordinator.gs
@@ -138,3 +138,18 @@ if (typeof ChatService === 'undefined') {
   ChatService = {};
 }
 ChatService.getChatLog = getChatHistory;
+ChatService.clearChat = clearChatHistory;
+ChatService.exportChatLog = exportChatLogToTimestampedSheet;
+
+function getChatLog() {
+  return getChatHistory();
+}
+
+function clearChat() {
+  clearChatHistory();
+  return getChatHistory();
+}
+
+function exportChatLog() {
+  exportChatLogToTimestampedSheet();
+}

--- a/fetchAndCacheModels.gs
+++ b/fetchAndCacheModels.gs
@@ -50,3 +50,7 @@ function fetchProviderModels(provider) {
   }
 }
 
+// Expose helper for other scripts expecting a namespaced function
+fetchAndCacheModels.getCachedProviderModels = getCachedProviderModels;
+
+

--- a/setupChatSidebar.html
+++ b/setupChatSidebar.html
@@ -1,5 +1,4 @@
 <!-- This file includes embedded JS/CSS due to project type rules -->
-<script>
 <html>
 <head>
   <base target="_top">
@@ -295,4 +294,3 @@
   </script>
 </body>
 </html>
-</script>


### PR DESCRIPTION
## Summary
- add missing global wrappers for chat history operations
- remove stray script tag in `setupChatSidebar.html`
- expose `getCachedProviderModels` as property of `fetchAndCacheModels`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6854d5d8f6a4832785704815e540f8f2